### PR TITLE
Add `client_secret` parameter to Password Grant

### DIFF
--- a/server/views/index.js
+++ b/server/views/index.js
@@ -734,6 +734,7 @@ $(function () {
     e.preventDefault();
     var opt = {
       client_id: $('#client_id').val(),
+      client_secret: $('#client_secret').val(),
       username: $('#username').val(),
       password: $('#password').val(),
       grant_type: 'password',


### PR DESCRIPTION
`POST` requests to `/oauth/token` require the `client_secret` parameter be present. Otherwise access is denied.

Close #74 .
